### PR TITLE
Fix bug on bower_components directory can't access in windows

### DIFF
--- a/www/app/bower_components
+++ b/www/app/bower_components
@@ -1,1 +1,0 @@
-../bower_components

--- a/www/gulpfile.js
+++ b/www/gulpfile.js
@@ -78,7 +78,10 @@ gulp.task('start:server', function() {
     root: [yeoman.app, '.tmp'],
     livereload: true,
     // Change this to '0.0.0.0' to access the server from outside.
-    port: 9000
+    port: 9000,
+    middleware: function(connect, opt){
+          return [['/bower_components', connect["static"]('./bower_components')]]
+    }
   });
 });
 


### PR DESCRIPTION
master clone到本地，部署后发现部分js文件报404。
问题原因，由于源项目是在mac环境下开发，出现了软链接在windows下无效的问题。
解决方案，在gulp文件的server中加入connect static中间件直接处理bower_components目录的请求，替代软链接

``` js
gulp.task('start:server', function() {
  $.connect.server({
    root: [yeoman.app, '.tmp'],
    livereload: true,
    port: 9000,
    middleware: function(connect, opt){
          return [['/bower_components', connect["static"]('./bower_components')]]
    }
  });
});
```
